### PR TITLE
add fix video fit

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -190,13 +190,16 @@ Site.HomeVideo = {
     if (_this.active) {
       // setup objects and vars
       _this.$video = $('#home-video');
-      _this.videoRatio = _this.$video.width() / _this.$video.height();
 
-      // scale video to fix
-      _this.layout();
+      _this.$video.on('loadeddata', function() {
+        _this.videoRatio = _this.$video.width() / _this.$video.height();
 
-      // fade in when ready
-      _this.showVideo();
+        // scale video to fix
+        _this.layout();
+
+        // fade in when ready
+        _this.showVideo();
+      });
     }
   },
 


### PR DESCRIPTION
I think i merged #80 too soon.

I moved those functions to run on `loadeddata` because the set of the videoRatio was wrongly set to `2` because it happened before the browser knew anything about the video.